### PR TITLE
delete the specified version in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The following resources are included.
 ```hcl
 module "vpc" {
   source  = "terraform-tencentcloud-modules/vpc/tencentcloud"
-  version = "1.0.3"
 
   vpc_name = "simple-vpc"
   vpc_cidr = "10.0.0.0/16"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38135414/107138519-d44bc380-694f-11eb-9ad0-b08517fdf5c0.png)
![image](https://user-images.githubusercontent.com/38135414/107138523-d6158700-694f-11eb-8b1a-6d34991375c1.png)
![image](https://user-images.githubusercontent.com/38135414/107138526-d877e100-694f-11eb-80d6-5a5bb40a7a5d.png)
When using the code in _readme.md_, the `terraform init` command failed because the specified version in _readme.md_ is an old version, which is not supported after changing the repo name. After deleting the specified version, the `terraform init` command works normally.